### PR TITLE
Specify parsers in the file type

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ ilib-lint accepts the following command-line parameters:
 * locales - Locales you want your app to support globally. Value is a comma-separated
   list of BCP-47 style locale tags. File types can override this list.
   Default: the top 20 locales on the internet by traffic.
+* progressinfo - whether or not to show progress information while finding and
+  parsing source files.s
 * sourceLocale - locale of the source files or the source locale for resource
   files. Default: "en-US"
 * quiet - Produce no progress output during the run, except for errors running
@@ -215,6 +217,7 @@ The linter plugin should override and implement these three methods:
 
 - getParsers - return an array of classes that inherit from the Parser class
 - getRules - return an array of classes that inherit from the Rule class
+- getRuleSets - return an array of named rule sets that define which rules to use
 - getFormatters - return an array of classes that inherit from the Formatter class
 
 For rules and formatters, each array entry can be either declarative or
@@ -378,6 +381,40 @@ the built-in ICU plural matcher rule:
 [resource-icu-plurals](https://github.com/ilib-js/ilib-lint/blob/main/src/rules/ResourceICUPlurals.js)
 which checks resources to make sure that plurals in source and target strings
 have the correct syntax for ICU and formatjs.
+
+### Rule Sets
+
+Rule sets are exactly what they sound like -- a named set that makes it easy
+to use a list of rules with a particular file type.
+
+Rule sets can be declared in the config file or can be returned from a plugin.
+By convention, at least one of the rulesets returned from each plugin typically
+names all of the rules that that plugin supports. That way, a configuration can
+be assured of using all the latest available rules when the version of the plugin
+is upgraded, without explicitly updating the config to name all of those new rules.
+
+Rule sets should be returned from the getRuleSets method of a plugin which are an
+object where the properties name the rule sets, and the value of each property is
+another object that lists the individual rules that are members of that set,
+and their possible parameters/initializers.
+
+Example return value from a call to getRuleSets:
+
+```javascript
+{
+    "javascript": {
+        "source-check-hard-coded-strings": true,
+        "source-check-icu-plural-syntax": {
+            "enforcement": "strict"
+        }
+    }
+}
+```
+
+In this example, one rule set "javascript" is returned, listing two rules. The
+first rule has the value `true` meaning that it is turned on. The second rule
+has an initializer telling the rule code to strictly enforce the plural
+syntax. (Each rule defines for itself what parameters/initalizers it accepts.)
 
 ### Formatters
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,6 +1,18 @@
 Release Notes
 ============================
 
+### v1.15.0
+
+- added the ability to specify which parsers to use for a particular
+  file type. This allows you to parse files that do not have the
+  standard file name extension for the file type. Example: the
+  "JavascriptReactJsx" parser automatically parses files with the
+  extension ".jsx" but in your project, the convention is to put them
+  in files with the extension ".js" instead. In this case, the mappings
+  should include an entry that maps "**/*.js" to a "react-jsx" file type
+  and the "react-jsx" file type should specify that files should be parsed
+  with the "JavascriptReactJsx" parser.
+
 ### v1.14.0
 
 - added a new rule to check whether or not replacement parameters in the
@@ -8,7 +20,7 @@ Release Notes
 - fixed a bug where the quote style checker was not checking quotes properly
   when the quotes surrounded a replacement parameter like "{this}"
 - added the ability to set sourceLocale through the config file.
-- added time eplased information in the result.
+- added time elapsed information in the result.
 - added a `progressinfo` option to know the which file is checking while the tool is running.
 - fixed the source plural category checker to not complain about extra
   categories in the source string other than the required "one" and "other"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-lint",
-    "version": "1.14.0",
+    "version": "1.15.0",
     "module": "./src/index.js",
     "type": "module",
     "bin": "./src/index.js",

--- a/package.json
+++ b/package.json
@@ -49,14 +49,10 @@
         "node": ">=14.0.0"
     },
     "scripts": {
-        "build": "npm run build:prod",
-        "build:prod": "grunt babel --mode=prod",
-        "build:dev": "grunt babel --mode=dev",
-        "build:test": "webpack-cli --config webpack-test.config.js",
-        "dist": "npm-run-all doc build:prod; npm pack",
-        "test": "LANG=en_US.UTF8 node --experimental-vm-modules ./node_modules/.bin/jest",
+        "dist": "npm pack",
+        "test": "LANG=en_US.UTF8 node --trace-warnings --experimental-vm-modules ./node_modules/.bin/jest",
         "test:watch": "LANG=en_US.UTF8 node --experimental-vm-modules ./node_modules/.bin/jest --watch",
-        "debug": "LANG=en_US.UTF8 npm run build:dev ; node --experimental-vm-modules --inspect-brk node_modules/.bin/jest -i",
+        "debug": "LANG=en_US.UTF8 node --trace-warnings --experimental-vm-modules --inspect-brk node_modules/.bin/jest -i",
         "lint": "node src/index.js",
         "clean": "git clean -f -d src test",
         "doc": "mkdir -p docs ; jsdoc2md -c jsdoc.json --separators --source src/* -m table > docs/ilibLint.md ; npm run doc:html",

--- a/src/FileType.js
+++ b/src/FileType.js
@@ -1,7 +1,7 @@
 /*
  * FileType.js - Represents a type of file in an ilib-lint project
  *
- * Copyright © 2023 JEDLSoft
+ * Copyright © 2023-2024 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -101,7 +101,7 @@ class FileType {
         }
 
         if (this.parsers) {
-            const parserMgr = project.getParserManager();
+            const parserMgr = this.project.getParserManager();
             this.parserClasses = this.parsers.map(parserName => {
                 const parser = parserMgr.getByName(parserName);
                 if (!parser) {

--- a/src/FileType.js
+++ b/src/FileType.js
@@ -54,7 +54,20 @@ class FileType {
      *   the template can be left out.
      * - ruleset (Array of String) - a list of rule set names
      *   to use with this file type
+     * - parsers (Array of String) - an array of names of parsers to
+     *   apply to this file type. This is mainly useful when the source
+     *   code is in a file with an unexpected or ambiguous file
+     *   name extension. For example, a ".js" file may contain
+     *   regular Javascript code, but it may also be React JSX
+     *   code, or even Javascript with JSX and Flow type definitions.
      *
+     * The array of parsers will be used to attempt to parse each
+     * source file. If a parser throws an exception/error while parsing,
+     * the linter will note that an error occurred and move on to
+     * the next parser to see if that one will work. If ALL parsers
+     * fail for a particular file, then this tool will print an
+     * error message to the output about it.
+     *  
      * @param {Object} options the options governing the construction
      * of this file type as documented above
      * @constructor
@@ -63,7 +76,7 @@ class FileType {
         if (!options || !options.name || !options.project) {
             throw "Missing required options to the FileType constructor";
         }
-        ["name", "project", "locales", "ruleset", "template", "type"].forEach(prop => {
+        ["name", "project", "locales", "ruleset", "template", "type", "parsers"].forEach(prop => {
             if (typeof(options[prop]) !== 'undefined') {
                 this[prop] = options[prop];
             }
@@ -86,6 +99,17 @@ class FileType {
                 this.ruleset = [ setName ];
             }
         }
+
+        if (this.parsers) {
+            const parserMgr = project.getParserManager();
+            this.parserClasses = this.parsers.map(parserName => {
+                const parser = parserMgr.getByName(parserName);
+                if (!parser) {
+                    throw `Could not find parser ${parserName} named in the configuration for filetype ${this.name}`;
+                }
+                return parser;
+            });
+        }
     }
 
     getName() {
@@ -106,6 +130,22 @@ class FileType {
 
     getType() {
         return this.type;
+    }
+
+    /**
+     * Return an array of classes of parsers to use with this file type.
+     * If the parsers are not named explicitly in the configuration,
+     * this method will check with the parser manager to find all parsers
+     * that can parse files with the given file name extension. If there
+     * are none available, this method returned undefined;
+     * @param {String} extension file name extension of the file being parsed
+     * @returns {Array.<Class>} an array of parser classes to use with
+     * files of this type.
+     */
+    getParserClasses(extension) {
+        if (this.parserClasses) return this.parserClasses;
+        const pm = this.project.getParserManager();
+        return pm.get(extension);
     }
 
     /**

--- a/src/FileType.js
+++ b/src/FileType.js
@@ -67,7 +67,7 @@ class FileType {
      * the next parser to see if that one will work. If ALL parsers
      * fail for a particular file, then this tool will print an
      * error message to the output about it.
-     *  
+     *
      * @param {Object} options the options governing the construction
      * of this file type as documented above
      * @constructor

--- a/src/ParserManager.js
+++ b/src/ParserManager.js
@@ -56,6 +56,16 @@ class ParserManager {
     }
 
     /**
+     * Return the parser with the given name.
+     * @param {String} name the name of the parser being sought
+     * @returns {Parser|undefined} the parser with the given name or undefined if
+     * none was found with that name.
+     */
+    getByName(name) {
+        // TODO: implement ParserManager.getByName()
+    }
+
+    /**
      * Add a list of parsers to this factory so that other code
      * can find them.
      *

--- a/src/ParserManager.js
+++ b/src/ParserManager.js
@@ -1,7 +1,7 @@
 /*
  * ParserManager.js - Factory to create and return the right parser for the file
  *
- * Copyright © 2022-2023 JEDLSoft
+ * Copyright © 2022-2024 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,7 @@ class ParserManager {
      */
     constructor(options) {
         this.parserCache = {};
+        this.parserByName = {};
         this.descriptions = {};
     }
 
@@ -62,7 +63,7 @@ class ParserManager {
      * none was found with that name.
      */
     getByName(name) {
-        // TODO: implement ParserManager.getByName()
+        return this.parserByName[name];
     }
 
     /**
@@ -85,6 +86,7 @@ class ParserManager {
                     this.parserCache[extension].push(parser);
                 }
                 this.descriptions[p.getName()] = p.getDescription();
+                this.parserByName[p.getName()] = parser;
 
                 logger.trace(`Added parser to the parser manager.`);
             } else {

--- a/src/Project.js
+++ b/src/Project.js
@@ -249,7 +249,7 @@ class Project extends DirItem {
      * @accept {boolean} true when everything was initialized correct
      * @reject the initialization failed
      */
-    init() {
+    async init() {
         let promise = Promise.resolve(true);
 
         if (this.config.plugins) {

--- a/src/Project.js
+++ b/src/Project.js
@@ -249,7 +249,7 @@ class Project extends DirItem {
      * @accept {boolean} true when everything was initialized correct
      * @reject the initialization failed
      */
-    async init() {
+    init() {
         let promise = Promise.resolve(true);
 
         if (this.config.plugins) {
@@ -322,6 +322,8 @@ class Project extends DirItem {
                 logger.error(`Could not find formatter ${options.formatter}. Aborting...`);
                 process.exit(3);
             }
+
+            return true;
         });
     }
 

--- a/src/SourceFile.js
+++ b/src/SourceFile.js
@@ -46,7 +46,7 @@ class SourceFile extends DirItem {
      */
     constructor(filePath, options, project) {
         super(filePath, options, project);
-        if (!options || !filePath) {
+        if (!options || !filePath || !options.filetype) {
             throw "Incorrect options given to SourceFile constructor";
         }
         this.filePath = filePath;
@@ -62,8 +62,7 @@ class SourceFile extends DirItem {
         if (extension) {
             // remove the dot
             extension = extension.substring(1);
-            const pm = project.getParserManager();
-            this.parserClasses = pm.get(extension);
+            this.parserClasses = this.filetype.getParserClasses(extension);
         }
     }
 
@@ -102,7 +101,17 @@ class SourceFile extends DirItem {
      */
     parse() {
         if (!this.filePath) return [];
-        return this.getParsers().flatMap((parser) => parser.parse());
+        const irs = this.getParsers().flatMap(parser => {
+            try {
+                return parser.parse();
+            } catch (e) {
+                logger.trace(`Parser ${parser.getName()} could not parse file ${this.filePath}`);
+            }
+        });
+        if (!irs || irs.length === 0) {
+            throw `All parsers failed to parse file ${file.filePath}. Try configuring another parser or excluding this file from the lint project.`;
+        }
+        return irs;
     }
 
     /**
@@ -140,12 +149,12 @@ class SourceFile extends DirItem {
                 for (const ir of irs) {
                     // find the rules that are appropriate for this intermediate representation and then apply them
                     const rules = this.filetype.getRules().filter((rule) => rule.getRuleType() === ir.getType());
-                    
-                    rules.forEach(function(ru){
-                    logger.debug('Checking rule  : ' + ru.name);
-                    })
+
+                    rules.forEach(ru => {
+                        logger.debug('Checking rule  : ' + ru.name);
+                    });
                     logger.debug('');
-                    
+
                     // apply rules
                     const results = rules.flatMap(
                         (rule) =>

--- a/src/SourceFile.js
+++ b/src/SourceFile.js
@@ -106,10 +106,11 @@ class SourceFile extends DirItem {
                 return parser.parse();
             } catch (e) {
                 logger.trace(`Parser ${parser.getName()} could not parse file ${this.filePath}`);
+                logger.trace(e);
             }
         });
         if (!irs || irs.length === 0) {
-            throw `All parsers failed to parse file ${file.filePath}. Try configuring another parser or excluding this file from the lint project.`;
+            throw `All available parsers failed to parse file ${file.filePath}. Try configuring another parser or excluding this file from the lint project.`;
         }
         return irs;
     }

--- a/src/config/README.md
+++ b/src/config/README.md
@@ -87,6 +87,17 @@ The `ilib-lint-config.json` file can have any of the following properties:
         the rules are a superset of all of the rules in the named rule sets.
         If the value is an object, then it is considered to be an on-the-fly
         unnamed rule set defined directly.
+    -   parsers (Array of String) - explicitly name the parsers to use when
+        parsing this type of file. If none are specified, then the linter will use
+        the parser that knows how to parse files with the file name extension
+        of the file being parsed. Eg, "js" files will be parsed by the
+        "Javascript" parser. The idea behind the parsers array is that in some
+        projects, there are some file types uses a non-standard file name
+        extension and thus none of the parsers knows how to parse it. For
+        example, your project might have have some ".jscript"
+        files in it, which are really Javascript, but the linter does not know
+        that yet. You would specify the "Javascript" parser in the "jscript" file
+        type to specify how to parse files of that type.
 -   paths (Object) - this maps sets of files to file types. The properties in this
     object are [micromatch](https://github.com/micromatch/micromatch) glob expressions
     that select a subset of files within the current project. The glob expressions
@@ -150,19 +161,27 @@ Here is an example of a configuration file:
     "filetypes": {
         "json": {
             // override the general locales
-            "locales": ["en-US", "de-DE", "ja-JP"]
+            "locales": ["en-US", "de-DE", "ja-JP"],
+            "ruleset": ["json"]
         },
         "javascript": {
             "ruleset": ["react-rules"]
         },
         "jsx": {
             "ruleset": ["react-rules"]
+        },
+        "sdl-xliff": {
+            // these are actually special xliff files in our project,
+            // so we can use the regular xliff parser to parse them
+            "parsers": [ "xliff" ],
+            "ruleset": ["resource"]
         }
     },
     // this maps micromatch path expressions to a file type definition
     "paths": {
         // use the file type defined above
         "src/**/*.json": "json",
+        "src/**/*.sdlxliff": "sdl-xliff",
         "src/**/*.js": "javascript",
         "src/**/*.jsx": "jsx",
         // define a file type on the fly

--- a/src/config/README.md
+++ b/src/config/README.md
@@ -172,7 +172,8 @@ Here is an example of a configuration file:
         },
         "sdl-xliff": {
             // these are actually special xliff files in our project,
-            // so we can use the regular xliff parser to parse them
+            // but they have the same syntax as regular xliff, so we can
+            // still use the regular xliff parser to parse them
             "parsers": [ "xliff" ],
             "ruleset": ["resource"]
         }

--- a/test/Project.test.js
+++ b/test/Project.test.js
@@ -272,7 +272,7 @@ describe("testProject", () => {
         expect(project.getSourceLocale()).toBe("en-KR");
     });
 
-    test("ProjectGetFileTypeForPath1", () => {
+    test("ProjectGetFileTypeForPath1", async () => {
         expect.assertions(2);
 
         const project = new Project("x", {pluginManager, opt: {}}, genericConfig);
@@ -284,7 +284,7 @@ describe("testProject", () => {
         expect(ft.getName()).toBe("json");
     });
 
-    test("ProjectGetFileTypeForPath2", () => {
+    test("ProjectGetFileTypeForPath2", async () => {
         expect.assertions(2);
 
         const project = new Project("x", {pluginManager, opt: {}}, genericConfig);
@@ -296,7 +296,7 @@ describe("testProject", () => {
         expect(ft.getName()).toBe("javascript");
     });
 
-    test("ProjectGetFileTypeForPathUnknown", () => {
+    test("ProjectGetFileTypeForPathUnknown", async () => {
         expect.assertions(2);
 
         const project = new Project("x", {pluginManager, opt: {}}, genericConfig);
@@ -308,7 +308,7 @@ describe("testProject", () => {
         expect(ft.getName()).toBe("unknown");
     });
 
-    test("ProjectGetFileTypeForPathNormalizePath", () => {
+    test("ProjectGetFileTypeForPathNormalizePath", async () => {
         expect.assertions(2);
 
         const project = new Project("x", {pluginManager, opt: {}}, genericConfig);
@@ -320,7 +320,7 @@ describe("testProject", () => {
         expect(ft.getName()).toBe("json");
     });
 
-    test("ProjectGetFileTypeForPathAnonymousFileType", () => {
+    test("ProjectGetFileTypeForPathAnonymousFileType", async () => {
         expect.assertions(2);
 
         const project = new Project("x", {pluginManager, opt: {}}, genericConfig);

--- a/test/Project.test.js
+++ b/test/Project.test.js
@@ -1,7 +1,7 @@
 /*
  * Project.test.js - test the project object
  *
- * Copyright © 2023 JEDLSoft
+ * Copyright © 2023-2024 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -278,6 +278,8 @@ describe("testProject", () => {
         const project = new Project("x", {pluginManager, opt: {}}, genericConfig);
         expect(project).toBeTruthy();
 
+        // must initialize the project before the filetypes are available
+        const result = await project.init();
         const ft = project.getFileTypeForPath("src/foo/ja/asdf.json");
         expect(ft.getName()).toBe("json");
     });
@@ -288,6 +290,8 @@ describe("testProject", () => {
         const project = new Project("x", {pluginManager, opt: {}}, genericConfig);
         expect(project).toBeTruthy();
 
+        // must initialize the project before the filetypes are available
+        const result = await project.init();
         const ft = project.getFileTypeForPath("src/foo/asdf.js");
         expect(ft.getName()).toBe("javascript");
     });
@@ -298,6 +302,8 @@ describe("testProject", () => {
         const project = new Project("x", {pluginManager, opt: {}}, genericConfig);
         expect(project).toBeTruthy();
 
+        // must initialize the project before the filetypes are available
+        const result = await project.init();
         const ft = project.getFileTypeForPath("notsrc/foo/ja/asdf.json");
         expect(ft.getName()).toBe("unknown");
     });
@@ -308,6 +314,8 @@ describe("testProject", () => {
         const project = new Project("x", {pluginManager, opt: {}}, genericConfig);
         expect(project).toBeTruthy();
 
+        // must initialize the project before the filetypes are available
+        const result = await project.init();
         const ft = project.getFileTypeForPath("./src/foo/ja/asdf.json");
         expect(ft.getName()).toBe("json");
     });
@@ -318,6 +326,8 @@ describe("testProject", () => {
         const project = new Project("x", {pluginManager, opt: {}}, genericConfig);
         expect(project).toBeTruthy();
 
+        // must initialize the project before the filetypes are available
+        const result = await project.init();
         const ft = project.getFileTypeForPath("i18n/it-IT.xliff");
         // since it is not a pre-defined xliff with a real name, it uses
         // the mapping's glob as the name

--- a/test/SourceFile.test.js
+++ b/test/SourceFile.test.js
@@ -1,7 +1,7 @@
 /*
  * SourceFile.test.js - test the source file class
  *
- * Copyright ©  2022-2023JEDLSoft
+ * Copyright © 2022-2024 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,19 +52,62 @@ const config = {
     }
 };
 
+const config2 = {
+    "name": "test2",
+    "locales": [
+        "en-US",
+        "de-DE",
+        "ja-JP",
+        "ko-KR"
+    ],
+    "plugins": [
+        "plugin-test"
+    ],
+    "excludes": [
+        "node_modules/**",
+        ".git/**",
+        "docs/**"
+    ],
+    "rulesets": {
+        "test": {
+            "resource-icu-plurals": true,
+            "resource-quote-style": true,
+            "resource-url-match": true,
+            "resource-named-params": "localeOnly"
+        }
+    },
+    "filetypes": {
+        "json-modified": {
+            "parsers": [ "parser-xyz" ],
+            "ruleset": [ "test" ]
+        }
+    },
+    "paths": {
+        // it has an odd filename extension, so we have to explicitly name the
+        // parser above as the one from our plugin-test
+        "**/*.pdq": "json-modified"
+    }
+};
+
 const project = new Project(".", {
     pluginManager: new PluginManager()
 }, config);
 
-const filetype = new FileType({
-    name: "javascript",
-    project
-});
+const project2 = new Project(".", {
+    pluginManager: new PluginManager()
+}, config2);
 
 describe("testSourceFile", () => {
+    beforeAll(() => {
+        return project.init().then(() => {
+            return project2.init();
+        });
+    });
+
     test("SourceFile", () => {
         expect.assertions(2);
 
+        const filetype = project.getFileTypeForPath("test/testfiles/test.xliff");
         const sf = new SourceFile("a", { filetype }, project);
         expect(sf).toBeTruthy();
         expect(sf.getFilePath()).toBe("a");
@@ -89,6 +132,7 @@ describe("testSourceFile", () => {
     test("SourceFileWithSettings", () => {
         expect.assertions(2);
 
+        const filetype = project.getFileTypeForPath("test/testfiles/test.xliff");
         const sf = new SourceFile("a", {
             settings: {
                 template: "x"
@@ -102,6 +146,7 @@ describe("testSourceFile", () => {
     test("SourceFileGetLocaleFromPath", () => {
         expect.assertions(2);
 
+        const filetype = project.getFileTypeForPath("src/filemanager/xrs/messages_de_DE.properties");
         const sf = new SourceFile("src/filemanager/xrs/messages_de_DE.properties", {
             settings: {
                 template: "[dir]/messages_[localeUnder].properties"
@@ -115,6 +160,7 @@ describe("testSourceFile", () => {
     test("SourceFileGetLocaleFromPathNone", () => {
         expect.assertions(2);
 
+        const filetype = project.getFileTypeForPath("src/filemanager/xrs/Excludes.java");
         const sf = new SourceFile("src/filemanager/xrs/Excludes.java", {
             settings: {
                 template: "[dir]/messages_[localeUnder].properties"
@@ -128,6 +174,7 @@ describe("testSourceFile", () => {
     test("SourceFileGetLocaleFromPathNoTemplate", () => {
         expect.assertions(2);
 
+        const filetype = project.getFileTypeForPath("src/filemanager/xrs/messages_de_DE.properties");
         const sf = new SourceFile("src/filemanager/xrs/messages_de_DE.properties", {
             settings: {
             },
@@ -139,7 +186,8 @@ describe("testSourceFile", () => {
 
     test("SourceFileParse", () => {
         expect.assertions(3);
-debugger;
+
+        const filetype = project.getFileTypeForPath("test/testfiles/xliff/test.xliff");
         const sf = new SourceFile("test/testfiles/xliff/test.xliff", {
             settings: {
             },
@@ -154,6 +202,7 @@ debugger;
     test("SourceFileParseRightContents", () => {
         expect.assertions(9);
 
+        const filetype = project.getFileTypeForPath("test/testfiles/xliff/test.xliff");
         const sf = new SourceFile("test/testfiles/xliff/test.xliff", {
             settings: {
             },
@@ -175,6 +224,7 @@ debugger;
     test("SourceFileParseRightTypeResource", () => {
         expect.assertions(5);
 
+        const filetype = project.getFileTypeForPath("test/testfiles/xliff/test.xliff");
         const sf = new SourceFile("test/testfiles/xliff/test.xliff", {
             settings: {
             },
@@ -191,6 +241,7 @@ debugger;
     test("SourceFileParseNonResourceFile", () => {
         expect.assertions(7);
 
+        const filetype = project.getFileTypeForPath("test/ilib-mock/index.js");
         const sf = new SourceFile("test/ilib-mock/index.js", {
             filetype,
             settings: {
@@ -205,5 +256,46 @@ debugger;
         const source = ir[0].getRepresentation();
         expect(source).toBeTruthy();
         expect(source.length).toBe(117); // how many chars in this source file?
+    });
+
+    test("SourceFile parse an oddly-named file using a named parser instead of the default one", () => {
+        expect.assertions(7);
+
+        const filetype = project2.getFileTypeForPath("test/testfiles/strings.pdq");
+        const sf = new SourceFile("test/testfiles/strings.pdq", {
+            filetype,
+            settings: {
+            }
+        }, project2);
+        expect(sf).toBeTruthy();
+        const ir = sf.parse();
+        expect(ir).toBeTruthy();
+        expect(Array.isArray(ir)).toBeTruthy();
+        expect(ir.length).toBe(1);
+        expect(ir[0].getType()).toBe("resource"); // from the xyz parser ilib-lint-plugin-test
+        const source = ir[0].getRepresentation();
+        expect(source).toBeTruthy();
+        expect(source.length).toBe(3); // how many resources in this resource file?
+    });
+
+    test("SourceFile parse an oddly-named file using the default parser not using a named parser", () => {
+        expect.assertions(7);
+
+        const filetype = project.getFileTypeForPath("test/testfiles/strings.pdq");
+        const sf = new SourceFile("test/testfiles/strings.pdq", {
+            filetype,
+            settings: {
+            }
+        }, project);
+        expect(sf).toBeTruthy();
+        const ir = sf.parse();
+        expect(ir).toBeTruthy();
+        expect(Array.isArray(ir)).toBeTruthy();
+        expect(ir.length).toBe(1);
+        // can't determine the file type, so it just parses it as one big string
+        expect(ir[0].getType()).toBe("string");
+        const source = ir[0].getRepresentation();
+        expect(source).toBeTruthy();
+        expect(source.length).toBe(78); // how many chars in this source file?
     });
 });

--- a/test/SourceFile.test.js
+++ b/test/SourceFile.test.js
@@ -65,7 +65,7 @@ describe("testSourceFile", () => {
     test("SourceFile", () => {
         expect.assertions(2);
 
-        const sf = new SourceFile("a", {}, project);
+        const sf = new SourceFile("a", { filetype }, project);
         expect(sf).toBeTruthy();
         expect(sf.getFilePath()).toBe("a");
     });
@@ -92,7 +92,8 @@ describe("testSourceFile", () => {
         const sf = new SourceFile("a", {
             settings: {
                 template: "x"
-            }
+            },
+            filetype
         }, project);
         expect(sf).toBeTruthy();
         expect(sf.getFilePath()).toBe("a");
@@ -104,7 +105,8 @@ describe("testSourceFile", () => {
         const sf = new SourceFile("src/filemanager/xrs/messages_de_DE.properties", {
             settings: {
                 template: "[dir]/messages_[localeUnder].properties"
-            }
+            },
+            filetype
         }, project);
         expect(sf).toBeTruthy();
         expect(sf.getLocaleFromPath()).toBe("de-DE");
@@ -116,7 +118,8 @@ describe("testSourceFile", () => {
         const sf = new SourceFile("src/filemanager/xrs/Excludes.java", {
             settings: {
                 template: "[dir]/messages_[localeUnder].properties"
-            }
+            },
+            filetype
         }, project);
         expect(sf).toBeTruthy();
         expect(sf.getLocaleFromPath()).toBe("");
@@ -127,7 +130,8 @@ describe("testSourceFile", () => {
 
         const sf = new SourceFile("src/filemanager/xrs/messages_de_DE.properties", {
             settings: {
-            }
+            },
+            filetype
         }, project);
         expect(sf).toBeTruthy();
         expect(sf.getLocaleFromPath()).toBe("");
@@ -135,10 +139,11 @@ describe("testSourceFile", () => {
 
     test("SourceFileParse", () => {
         expect.assertions(3);
-
+debugger;
         const sf = new SourceFile("test/testfiles/xliff/test.xliff", {
             settings: {
-            }
+            },
+            filetype
         }, project);
         expect(sf).toBeTruthy();
         const resources = sf.parse();
@@ -151,7 +156,8 @@ describe("testSourceFile", () => {
 
         const sf = new SourceFile("test/testfiles/xliff/test.xliff", {
             settings: {
-            }
+            },
+            filetype
         }, project);
         expect(sf).toBeTruthy();
         const ir = sf.parse();
@@ -171,7 +177,8 @@ describe("testSourceFile", () => {
 
         const sf = new SourceFile("test/testfiles/xliff/test.xliff", {
             settings: {
-            }
+            },
+            filetype
         }, project);
         expect(sf).toBeTruthy();
         const ir = sf.parse();

--- a/test/ilib-lint-plugin-test/package.json
+++ b/test/ilib-lint-plugin-test/package.json
@@ -1,6 +1,6 @@
 {
     "name": "i18nlint-plugin-test",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "main": "./src/index.js",
     "type": "module",
     "exports": {

--- a/test/ilib-lint-plugin-test/src/TestParser.js
+++ b/test/ilib-lint-plugin-test/src/TestParser.js
@@ -1,7 +1,7 @@
 /*
  * TestParser.js - test an ilib-lint Parser plugin
  *
- * Copyright © 2022 JEDLSoft
+ * Copyright © 2022, 2024 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ class TestParser extends Parser {
     constructor(options) {
         super(options);
         this.name = "parser-xyz";
+        this.description = "A test parser for xyz files, which are really just json files.";
         this.filePath = options && options.filePath;
     }
 

--- a/test/testfiles/strings.pdq
+++ b/test/testfiles/strings.pdq
@@ -1,0 +1,5 @@
+{
+    "string1": "value1",
+    "string2": "value2",
+    "string3": "value3"
+}


### PR DESCRIPTION
- allows you to specify which parsers to use with the file type in the case where the file type uses some odd file name extension that the parsers don't recognize
- moved configuration processing from the Project constructor to the init method because we have to be able to load plugins first before we can process the configuration. The config may reference some of the parsers, rulesets, etc. that the plugins provide.
- updated some documentation
- cleaned some unnecessary stuff from the package.json
- added the ability for the parser manager to retrieve parsers by their name instead of only by file name extension
- now catches exceptions produced by the parsers for any given file, and only throws an error if ALL of the parsers fail to parse that file.