### PR TITLE
Add missing rule documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,24 @@ The built-in rules are:
   all resource files
 - [resource-url-match](./docs/resource-url-match.md) - If the source string contains references to URLs, check
   that the target string also contains references to the same URLs
-
+- [source-icu-plural-params](./docs/source-icu-plural-params.md) - Make sure the "one" category contains the same
+replacement parameter as the "other" category
+- [source-icu-unexplained-params](./docs/source-icu-unexplained-params.md) - Ensure that every replacement parameter
+in the source string is explained in the translator's note
+- [source-no-dashes-in-replacement-params](./docs/source-no-dashes-in-replacement-params.md) - Do not allow dashes
+in the names of replacement parameters
+- [source-no-escaped-curly-braces](./docs/source-no-escaped-curly-braces.md) - Do not put single quotes around
+replacement parameters
+- [source-no-lazy-plurals](./docs/source-no-lazy-plurals.md) - Do not use the construct "(s)" to indicate either
+singular or plural. Use a real plural string instead.
+- [source-no-manual-currency-formatting](./docs/source-no-manual-currency-formatting.md) - Do not manually format
+currency. Use a number formatter instead.
+- [source-no-manual-date-formatting](./docs/source-no-manual-date-formatting.md) - Do not manually format dates.
+Use a date formatter instead.
+- [source-no-manual-percentage-formatting](./docs/source-no-manual-percentage-formatting.md) - Do not manually
+format percentages. Use a number formatter instead.
+- [source-no-noun-replacement-params](./docs/source-no-noun-replacement-params.md) - Do not use the untranslatable
+construct "the {param}" or "a {param}"
 
 ## Writing Plugins
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -12,6 +12,7 @@ Release Notes
   should include an entry that maps "**/*.js" to a "react-jsx" file type
   and the "react-jsx" file type should specify that files should be parsed
   with the "JavascriptReactJsx" parser.
+- fixed some problems with the documentation
 
 ### v1.14.0
 

--- a/docs/resource-icu-plurals-translated.md
+++ b/docs/resource-icu-plurals-translated.md
@@ -1,0 +1,24 @@
+# resource-icu-plurals-translated
+
+ICU-style plurals and selects are notoriously difficult for translators to get right.
+This is because they are professional linguists, not programmers, and are usually
+not clear on concepts like "balanced brackets" and such. To be fair, the syntax
+is rather complicated, and if their translation tool does not automatically
+pick out which parts need to be translated and which do not, they sometimes do not
+interpret the plural syntax properly despite their best efforts. This means they end
+up not translating parts of the string that do in fact need a translation.
+
+If you got this warning, it means that the translator did not translate one or
+more of the categories of a plural or select and it is the exact same string as in
+the source. Sometimes, this is okay because the translation of the source string
+is exactly the same in the target language, which means you can ignore this warning.
+This is why this rule produces warnings instead of errors. A majority of the time,
+however, it is a case of a missed translation.
+
+Example:
+
+English: "{numberOfFiles, plural, one {# file} other {# files}}"<br>
+German: "{numberOfFiles, plural, one {# file} other {# Dateien}}
+
+In this case, the German translator missed the "one" category. The string will
+need to be sent back to the translator for retranslation.

--- a/docs/source-no-dashes-in-replacement-params.md
+++ b/docs/source-no-dashes-in-replacement-params.md
@@ -1,0 +1,9 @@
+# source-no-dashes-in-replacement-params
+
+The formatjs libraries (as used as part of react-intl for example) do not
+allow replacement parameters to contain a dash character in the name of
+the parameter. If you got this error, simply rename your replacement
+parameter and modify your code to match.
+
+Bad replacement parameter: {this-doesnt-work}<br>
+Good replacement parameters: {thisWorks}  or {this_works}

--- a/docs/source-no-lazy-plurals.md
+++ b/docs/source-no-lazy-plurals.md
@@ -11,10 +11,10 @@ impossible to translate it properly.
 
 German:
 
-"Auto" (car) -> "Autos" (cars)  add an "s" suffix
-"Tisch" (table) -> "Tische" (tables)  add an "e" suffix
-"Fuß" (foot) -> "Füße" (feet) add an "e" and modify the central vowel
-"Bäcker" (baker) -> "Bäcker" (bakers)  no suffix for this plural
+- "Auto" (car) -> "Autos" (cars)  add an "s" suffix
+- "Tisch" (table) -> "Tische" (tables)  add an "e" suffix
+- "Fuß" (foot) -> "Füße" (feet) add an "e" and modify the central vowel
+- "Bäcker" (baker) -> "Bäcker" (bakers)  no suffix for this plural
 
 Instead, you should use the proper plural syntax for your i18n library.
 React-intl, for example, uses the ICU messageformat syntax as in this

--- a/docs/source-no-manual-currency-formatting.md
+++ b/docs/source-no-manual-currency-formatting.md
@@ -33,7 +33,7 @@ const messages = defineMessages({
     }
 });
 
-<FormattedMessage ...messages.monthlySubscriptionFee values={{
+<FormattedMessage {...messages.monthlySubscriptionFee} values={{
     cost: <FormattedNumber
         value={this.fees.monthly}
         currency={this.user.preferredCurrency}

--- a/docs/source-no-manual-date-formatting.md
+++ b/docs/source-no-manual-date-formatting.md
@@ -42,7 +42,7 @@ const messages = defineMessages({
     }
 });
 
-<FormattedMessage ...messages.deploymentStarted values={{
+<FormattedMessage {...messages.deploymentStarted} values={{
     formattedDateTime: <FormattedDate
         value={deployment.getStart()}
         year: "numeric"

--- a/docs/source-no-manual-percentage-formatting.md
+++ b/docs/source-no-manual-percentage-formatting.md
@@ -33,7 +33,7 @@ const messages = defineMessages({
     }
 });
 
-<FormattedMessage ...messages.percentUploaded values={{
+<FormattedMessage {...messages.percentUploaded} values={{
     pctFiles: <FormattedNumber
         value={numUploaded/totalRequest}
         style="percent"

--- a/docs/source-no-noun-replacement-params.md
+++ b/docs/source-no-noun-replacement-params.md
@@ -30,19 +30,19 @@ fix for them is different in each scenario.
 
     ```javascript
         import messages from './messages.js';
-    
+
         const messageMap = {
-            "file": messages.delete.file,
-            "folder": messages.delete.folder
+            "file": messages.deleteFile,
+            "folder": messages.deleteFolder
         };
         const deleteObjString = messageMap[objectToDelete.type];
-    
+
         [...]
             <MyDialog type="delete">
                 <FormattedMessage {...deleteObjString} />
             </MyDialog>
     ```
-    
+
     As an engineer, you may think that sharing the string is more efficient, as both strings
     are exactly the same except for the one word, but you are not really saving a lot of
     memory or disk footprint, and instead you are creating an untranslatable string.
@@ -51,14 +51,14 @@ fix for them is different in each scenario.
     from a 3rd party library or service, the way you avoid this problem is to make the string
     ungrammatical. That is, you still substitute the value into the string, but you make
     sure that the text being substituted is not grammatically related to the rest of the
-    string.
-    
+    string. The usual way of doing this is to use a colon followed by the replacement param.
+
     Here is the first example again, but expressed in a non-grammatical way.
-    
+
     ```plaintext
     Delete an object with this type: {fileType}
     ```
-    
+
     Now when you substitute in any word for "fileType", the rest of the string does not need
     to agree with the plurality or gender of the value of "fileType".
 


### PR DESCRIPTION
- add documentation for rules resource-icu-plurals-translated and source-no-dashes-in-replacement-params
- added rule summaries in the README
- fixed some inaccuracies