### PR TITLE
Fix the way that plugins are loaded

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -4,15 +4,27 @@ Release Notes
 ### v2.0.1
 
 - fixed loading of plugins
-    - if a plugin ilib-lint-x exists and also a different package x
-      exists that is unrelated to ilib-lint, it would first attempt
-      to load x, succeed, and then fail because x does not depend on
-      ilib-lint-common properly without trying any other paths or
-      plugins. This means it would not load the perfectly valid plugin
-      that is there. Instead, now it attempts to load ilib-lint-x first
-      in various places and then if it fails or does not pass the
-      ilib-lint-common dependency test, it falls back to loading the
-      plain x package next.
+    - if a plugin `ilib-lint-x` exists and a different package `x`
+      also exists that is unrelated to ilib-lint, and the config
+      says to load the plugin named simply `x`, it would first attempt
+      to load package `x`, succeed to load it, but then fail to
+      initialize it because `x` is not really an ilib-lint plugin.
+    - Another problem is that if this type of error occurred, it
+      would not attempt to load any other paths or plugins. This means
+      it would not load the perfectly valid plugin that is there
+      just because there was a conflicting package name.
+    - Additionally, if given a path directly to the plugin (absolute
+      or relative), it would not load that specific plugin and just
+      fail completely.
+    - Now, it:
+        - loads the specific plugin given a path to it
+        - if the plugin name is specified with the prefix like
+          `ilib-lint-x` it will attempt to load that package in various
+          locations until it finds one that works
+        - if the name is specified as simply `x`, it will attempt to
+          load the `ilib-lint-x` package first and only if it fails to
+          load or does not initialize properly will it fall back to
+          attempting to load the package just named just `x`
 - updated dependencies
 
 ### v2.0.0

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -1,6 +1,20 @@
 Release Notes
 ============================
 
+### v2.0.1
+
+- fixed loading of plugins
+    - if a plugin ilib-lint-x exists and also a different package x
+      exists that is unrelated to ilib-lint, it would first attempt
+      to load x, succeed, and then fail because x does not depend on
+      ilib-lint-common properly without trying any other paths or
+      plugins. This means it would not load the perfectly valid plugin
+      that is there. Instead, now it attempts to load ilib-lint-x first
+      in various places and then if it fails or does not pass the
+      ilib-lint-common dependency test, it falls back to loading the
+      plain x package next.
+- updated dependencies
+
 ### v2.0.0
 
 - updated to use ilib-lint-common instead of i18nlint-common. (Same library, new name.)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-lint",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "module": "./src/index.js",
     "type": "module",
     "bin": "./src/index.js",
@@ -61,24 +61,24 @@
     },
     "devDependencies": {
         "@tsconfig/node14": "^14.1.0",
-        "@types/node": "^20.8.5",
+        "@types/node": "^20.11.27",
         "docdash": "^2.0.2",
         "ilib-lint-plugin-test": "file:test/ilib-lint-plugin-test",
         "ilib-lint-plugin-obsolete": "file:test/ilib-lint-plugin-obsolete",
         "i18nlint-plugin-test-old": "file:test/i18nlint-plugin-test-old",
         "jest": "^29.7.0",
         "jsdoc": "^4.0.2",
-        "jsdoc-to-markdown": "^8.0.0",
+        "jsdoc-to-markdown": "^8.0.1",
         "npm-run-all": "^4.1.5",
-        "typescript": "^5.2.2"
+        "typescript": "^5.4.2"
     },
     "dependencies": {
-        "@formatjs/intl": "^2.9.3",
+        "@formatjs/intl": "^2.10.0",
         "ilib-common": "^1.1.3",
         "ilib-lint-common": "^3.0.0",
         "ilib-locale": "^1.2.2",
-        "ilib-localeinfo": "^1.0.5",
-        "ilib-tools-common": "^1.8.1",
+        "ilib-localeinfo": "^1.1.0",
+        "ilib-tools-common": "^1.9.1",
         "intl-messageformat": "^10.5",
         "json5": "^2.2.3",
         "log4js": "^6.9.1",

--- a/src/PluginManager.js
+++ b/src/PluginManager.js
@@ -42,41 +42,19 @@ function checkVersion(json, name) {
 
 /**
  * @private
- */
+ *
 function attemptLoad(name) {
     logger.trace(`Trying module ${name}`);
-    return import(name);
-};
-
-/**
- * Needed because node does not know how to load ES modules
- * from a path. (Even though that is what it does when you
- * just name the module without a path. Sigh.)
- *
- * @private
- */
-function attemptLoadPath(name) {
-    logger.trace(`Trying directory module ${name}`);
-    let packagePath = name;
-    const packageName = path.join(name, "package.json");
-    if (fs.existsSync(name) && fs.existsSync(packageName)) {
-        const data = fs.readFileSync(packageName, "utf-8");
-        const json = JSON.parse(data);
+    return import(name).then(module => {
+        logger.trace(`Module ${name} loaded with package name ${pkgName}.`);
+        const modulePath = path.join(this.resolve(name), "package.json");
+        const packageJsonContent = fs.readFileSync(modulePath, 'utf-8');
+        const json = JSON.parse(packageJsonContent);
         checkVersion(json, name);
-        if (json.type === "module") {
-            let relativePath = json.module;
-            if (!relativePath && json.exports) {
-                const keys = Object.keys(json.exports);
-                relativePath = keys.length && json.exports[keys[0]].import;
-            }
-            if (relativePath) {
-                packagePath = path.join(name, relativePath);
-            }
-        }
-    }
-    logger.trace(`Path to this module is ${packagePath}`);
-    return import(packagePath);
-}
+        return module;
+    });
+};
+*/
 
 /**
  * @class Represent a plugin manager, which loads a list of plugins
@@ -110,69 +88,112 @@ class PluginManager {
         this.resolve = createRequire(import.meta.url).resolve;
     }
 
-    /*
-     * Attempt to load the plugin in various places:
-     *
-     * - from the node_modules where ilib-lint was loaded
-     * - from the current directory's node_modules
-     * - from the plugins directory one directory up
-     *
-     * Each time it attempts to load it, it will try two ways:
-     *
-     * - As-is. Maybe it is a fully specified package name?
-     * - With the "ilib-lint-" prefix. Try again except with
-     * the prefix. This allows the users to configure plugins
-     * in the config file more tersely, similar to the way
-     * babel plugins can be named with only the unique part.
-     * The old "i18nlint-" prefix is no longer accepted in
-     * either the name of the directory or the name of the
-     * package.
+    /**
+     * Needed because node does not know how to load ES modules
+     * from a path. (Even though that is what it does when you
+     * just name the module without a path. Sigh.)
      *
      * @private
      */
-    loadPlugin(name) {
-        let pkgName = name;
-        return attemptLoad(pkgName).catch(e1 => {
-            logger.trace(e1);
-            pkgName = `ilib-lint-${name}`;
-            return attemptLoad(pkgName).catch(e2 => {
-                logger.trace(e2);
-                pkgName = path.join(process.cwd(), "node_modules", name);
-                return attemptLoadPath(pkgName).catch(e3 => {
-                    logger.trace(e3);
-                    pkgName = path.join(process.cwd(), "node_modules", `ilib-lint-${name}`);
-                    return attemptLoadPath(pkgName).catch(e4 => {
-                        logger.trace(e4);
-                        pkgName = path.join(process.cwd(), "..", "plugins", name + ".js")
-                        return attemptLoad(pkgName).catch(e5 => {
-                            logger.trace(e5);
-                            // on the last attempt, don't catch the exception. Just let it
-                            // go to the overall `catch` clause below.
-                            pkgName = path.join(process.cwd(), "..", "plugins", `ilib-lint-${name}` + ".js")
-                            return attemptLoad(pkgName);
-                        });
-                    });
-                });
-            });
-        }).then((module) => {
-            logger.trace(`Module ${name} loaded with package name ${pkgName}.`);
-            const modulePath = this.resolve(path.join(pkgName, "package.json"));
-            const packageJsonContent = fs.readFileSync(modulePath, 'utf-8');
-            const json = JSON.parse(packageJsonContent);
+    async attemptLoad(name) {
+        logger.trace(`Trying module ${name}`);
+        let packagePath = name;
+        const packageName = this.resolve(path.join(name, "package.json"));
+        if (fs.existsSync(packageName)) {
+            const data = fs.readFileSync(packageName, "utf-8");
+            const json = JSON.parse(data);
             checkVersion(json, name);
+            if (json.type === "module") {
+                let relativePath = json.module;
+                if (!relativePath && json.exports) {
+                    const keys = Object.keys(json.exports);
+                    relativePath = keys.length && json.exports[keys[0]].import;
+                }
+                if (relativePath) {
+                    packagePath = path.join(name, relativePath);
+                }
+            }
+        }
+        logger.trace(`Path to this module is ${packagePath}`);
+        return import(packagePath);
+    }
 
-            logger.trace(`Module ${name} successfully loaded.`);
-            const Main = module.default;
-            const plugin = new Main({
-                getLogger: log4js.getLogger.bind(log4js)
-            });
-            plugin.init();
-            return plugin;
-        }).catch(e2 => {
-            logger.error(`Could not load plugin ${name}. If you have a plugin, make sure it is upgraded and depends on ilib-lint-common v3.0.0 or greater.`);
-            logger.trace(e2);
+    /*
+     * Attempt to load the plugin.
+     *
+     * If the name is given with an absolute or relative path,
+     * then it will only try to load from that path, as the caller
+     * meant to load a very specific plugin. If the name is given as
+     * just a package name, it will attemp to load from various places:
+     *
+     * - from the current directory's node_modules
+     * - from the node_modules where ilib-lint was loaded
+     * - from the plugins directory one directory up
+     * - from the global node_modules
+     *
+     * Each time it attempts to load it, it will try two ways:
+     *
+     * - With the "ilib-lint-" prefix. Try with the prefix added to the
+     * name if it was not there already. This allows the users to configure
+     * plugins in the config file more tersely, similar to the way babel
+     * plugins can be named with only the unique part. The old "i18nlint-"
+     * prefix is no longer accepted in either the name of the directory
+     * or the name of the package.
+     * - As-is. Maybe it is a fully specified package name and doesn't have
+     * the prefix?
+     *
+     * @private
+     */
+    async loadPlugin(name) {
+        const nameparts = path.parse(name);
+
+        let pathsToTry;
+        if (nameparts.dir && nameparts.dir !== ".") {
+            // If it's a relative or absolute path, then only try this path. Do not add
+            // any prefixes or try any other directory or anything.
+            pathsToTry = [name];
+        } else if (nameparts.base.startsWith("ilib-lint-")) {
+            pathsToTry = [
+                path.join(process.cwd(), "node_modules", nameparts.base),
+                name,
+                path.join(process.cwd(), "..", "plugins", nameparts.name + ".js")
+            ];
+        } else {
+            const base = `ilib-lint-${nameparts.base}`;
+            // try the paths with the ilib-lint prefix first, and then try the ones
+            // without afterwards
+            pathsToTry = [
+                path.join(process.cwd(), "node_modules", base),
+                base,
+                path.join(process.cwd(), "..", "plugins", `ilib-lint-${nameparts.name}` + ".js"),
+                path.join(process.cwd(), "node_modules", nameparts.base),
+                name,
+                path.join(process.cwd(), "..", "plugins", nameparts.name + ".js"),
+            ];
+        }
+
+        let pkgName, module;
+        while ((pkgName = pathsToTry.shift())) {
+            try {
+                module = await this.attemptLoad(pkgName);
+                break;
+            } catch (e) {
+                logger.trace(e);
+            }
+        }
+
+        if (!module) {
+            logger.error(`Could not load plugin ${name}. If you know that you have a plugin, make sure it is upgraded and depends on ilib-lint-common v3.0.0 or greater.`);
             return undefined;
+        }
+
+        logger.trace(`Module ${name} successfully loaded.`);
+        const Main = module.default;
+        const plugin = new Main({
+            getLogger: log4js.getLogger.bind(log4js)
         });
+        plugin.init();
+        return plugin;
     };
 
     /**

--- a/src/PluginManager.js
+++ b/src/PluginManager.js
@@ -41,22 +41,6 @@ function checkVersion(json, name) {
 }
 
 /**
- * @private
- *
-function attemptLoad(name) {
-    logger.trace(`Trying module ${name}`);
-    return import(name).then(module => {
-        logger.trace(`Module ${name} loaded with package name ${pkgName}.`);
-        const modulePath = path.join(this.resolve(name), "package.json");
-        const packageJsonContent = fs.readFileSync(modulePath, 'utf-8');
-        const json = JSON.parse(packageJsonContent);
-        checkVersion(json, name);
-        return module;
-    });
-};
-*/
-
-/**
  * @class Represent a plugin manager, which loads a list of plugins
  * and then maintains references to them
  */

--- a/test/PluginManager.test.js
+++ b/test/PluginManager.test.js
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+import path from "node:path";
+
 import PluginManager from '../src/PluginManager.js';
 import { Parser, Result, SourceFile } from 'ilib-lint-common';
 import { ResourceString } from 'ilib-tools-common';
@@ -128,7 +130,7 @@ describe("testPluginManager", () => {
         });
     });
 
-    test("PluginManagerGetLoadPluginRightFormatter", () => {
+    test("PluginManager load the right plugin with the ilib-lint- prefix", () => {
         expect.assertions(5);
 
         const plgmgr = new PluginManager();
@@ -180,6 +182,68 @@ __Source_string_should_not_contain_the_word_"test"
 __Key:_formatter.test
 __Source:_This_string_has_the_word_>>test<<_in_it.
 __Rule_(resource-test):_Test_for_the_existence_of_the_word_'test'_in_the_strings.\n`);
+        });
+    });
+
+    test("PluginManager load the right plugin without the ilib-lint- prefix", () => {
+        expect.assertions(5);
+
+        const plgmgr = new PluginManager();
+        expect(plgmgr).toBeTruthy();
+
+        return plgmgr.load([
+            "plugin-test"
+        ]).then(result => {
+            expect(result).toBeTruthy();
+
+            const fm = plgmgr.getFormatterManager();
+            expect(fm).toBeTruthy();
+            // the plugin "plugin-test" does not have a formatter, but the
+            // "ilib-lint-plugin-test" does, so if we got the wrong one without the prefix,
+            // this below would fail
+            const formatter = fm.get("formatter-test");
+            expect(formatter).toBeTruthy();
+            expect(formatter.getName()).toBe("formatter-test");
+        });
+    });
+
+    test("PluginManager load the specific plugin if given an absolute path", () => {
+        expect.assertions(4);
+
+        const plgmgr = new PluginManager();
+        expect(plgmgr).toBeTruthy();
+        const fullPath = path.join(process.cwd(), "test", "plugin-test");
+        return plgmgr.load([
+            fullPath
+        ]).then(result => {
+            expect(result).toBeTruthy();
+
+            const fm = plgmgr.getFormatterManager();
+            expect(fm).toBeTruthy();
+            // the plugin "plugin-test" does not have a formatter, so if we got the wrong
+            // one (the one with the prefix), then formatter will be not undefined
+            const formatter = fm.get("formatter-test");
+            expect(formatter).toBeFalsy();
+        });
+    });
+
+    test("PluginManager load the specific plugin if given a relative path", () => {
+        expect.assertions(4);
+
+        const plgmgr = new PluginManager();
+        expect(plgmgr).toBeTruthy();
+        const relPath = path.join("test", "plugin-test");
+        return plgmgr.load([
+            relPath
+        ]).then(result => {
+            expect(result).toBeTruthy();
+
+            const fm = plgmgr.getFormatterManager();
+            expect(fm).toBeTruthy();
+            // the plugin "plugin-test" does not have a formatter, so if we got the wrong
+            // one (the one with the prefix), then formatter will be not undefined
+            const formatter = fm.get("formatter-test");
+            expect(formatter).toBeFalsy();
         });
     });
 

--- a/test/plugin-test/package.json
+++ b/test/plugin-test/package.json
@@ -1,0 +1,25 @@
+{
+    "name": "plugin-test",
+    "version": "1.0.0",
+    "main": "./src/index.js",
+    "type": "module",
+    "exports": {
+        ".": {
+            "import": "./src/index.js"
+        }
+    },
+    "description": "mock ilib-lint plugin package used for testing the plugin functionality",
+    "files": [
+        "src",
+        "package.json"
+    ],
+    "scripts": {
+        "test": "echo Success!"
+    },
+    "dependencies": {
+        "ilib-lint-common": "^3.0.0",
+        "ilib-locale": "^1.2.2",
+        "ilib-tools-common": "^1.9.1",
+        "json5": "^2.2.3"
+    }
+}

--- a/test/plugin-test/src/index.js
+++ b/test/plugin-test/src/index.js
@@ -1,0 +1,63 @@
+/*
+ * index.js - main program of ilib-lint plugin test
+ *
+ * Copyright © 2024 JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Plugin } from 'ilib-lint-common';
+
+class TestPlugin extends Plugin {
+    constructor(options) {
+        super(options);
+    }
+
+    init() {
+        //console.log("TestPlugin.init() called");
+    }
+
+    getExtensions() {
+        //console.log("TestPlugin.getExtensions() called");
+        return [ "xyz" ];
+    }
+
+    getRules() {
+        //console.log("TestPlugin.getRules() called");
+        return [ ];
+    }
+
+    getRuleSets() {
+        return {
+            "bad": "bad-bad-bad"
+        };
+    }
+
+    getParsers() {
+        //console.log("TestPlugin.getParsers() called");
+        return [ ];
+    }
+
+    getFormatters() {
+        //console.log("TestPlugin.getFormatters() called");
+        return [ ];
+    }
+
+    getFixers() {
+        return [ ];
+    }
+
+}
+
+export default TestPlugin;


### PR DESCRIPTION
- fixed loading of plugins
    - if a plugin `ilib-lint-x` exists and a different package `x`
      also exists that is unrelated to ilib-lint, and the config
      says to load the plugin named simply `x`, it would first attempt
      to load package `x`, succeed to load it, but then fail to
      initialize it because `x` is not really an ilib-lint plugin.
    - Another problem is that if this type of error occurred, it
      would not attempt to load any other paths or plugins. This means
      it would not load the perfectly valid plugin that is there
      just because there was a conflicting package name.
    - Additionally, if given a path directly to the plugin (absolute
      or relative), it would not load that specific plugin and just
      fail completely.
    - Now, it:
        - loads the specific plugin given a path to it
        - if the plugin name is specified with the prefix like
          `ilib-lint-x` it will attempt to load that package in various
          locations until it finds one that works
        - if the name is specified as simply `x`, it will attempt to
          load the `ilib-lint-x` package first and only if it fails to
          load or does not initialize properly will it fall back to
          attempting to load the package just named just `x`
- updated dependencies
