### PR TITLE
fixed a bug where the quote style checker was not converting the highlight quotes properly

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -1,5 +1,7 @@
 Release Notes
 ============================
+### v2.0.2
+- fixed a bug where the quote style checker was not converting the highlight quotes properly
 
 ### v2.0.1
 - fixed loading of plugins

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-lint",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "module": "./src/index.js",
     "type": "module",
     "bin": "./src/index.js",

--- a/src/rules/ResourceQuoteStyle.js
+++ b/src/rules/ResourceQuoteStyle.js
@@ -149,7 +149,7 @@ class ResourceQuoteStyle extends ResourceRule {
             endQuote = new RegExp(`([\\p{Letter}\\}])([${regExps.target.nonQuoteChars}'])(\\W|$)`, "gu");
         } else if (sourceStyle.asciiAlt) {
             if (regExps.target.quotesAllAlt.test(tar)) return;
-            startQuote = new RegExp(`(^|\\W)[${regExps.target.nonQuoteCharsAlt}"]([\\p{Letter}\\{])`, "gu");
+            startQuote = new RegExp(`(^|\\W)([${regExps.target.nonQuoteCharsAlt}"])([\\p{Letter}\\{])`, "gu");
             endQuote = new RegExp(`([\\p{Letter}\\}])([${regExps.target.nonQuoteCharsAlt}"])(\\W|$)`, "gu");
         } else if (sourceStyle.native) {
             if (regExps.target.quotesNative.test(tar)) return;

--- a/test/ResourceQuoteStyle.test.js
+++ b/test/ResourceQuoteStyle.test.js
@@ -329,6 +329,40 @@ describe("testResourceQuoteStyle", () => {
         expect(actual).toStrictEqual(expected);
     });
 
+    test("ResourceQuoteStyleMatchAlternate2", () => {
+        expect.assertions(2);
+
+        const rule = new ResourceQuoteStyle();
+        expect(rule).toBeTruthy();
+
+        const resource = new ResourceString({
+            key: "quote.test",
+            sourceLocale: "en-US",
+            source: "Please set your PIN code from 'Menu > PIN Code'.",
+            targetLocale: "af-ZA",
+            target: 'Stel asseblief u PIN-kode vanaf “Kieslys > PIN-kode”.',
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b"
+        });
+        const expected = new Result({
+            severity: "warning",
+            description: "Quote style for the locale af-ZA should be ‘text’",
+            id: "quote.test",
+            source: "Please set your PIN code from 'Menu > PIN Code'.",
+            highlight: "Target: Stel asseblief u PIN-kode vanaf <e0>“</e0>Kieslys > PIN-kode<e1>”</e1>.",
+            rule,
+            locale: "af-ZA",
+            pathName: "a/b"
+        });
+
+        expect(actual).toStrictEqual(expected);
+    });
+
     test("ResourceQuoteStyleMatchSimpleNoError", () => {
         expect.assertions(2);
 


### PR DESCRIPTION
fixed a bug where the quote style checker was not converting the highlight quotes properly
If not, the capturing $3 group is missing.