### PR TITLE
Filter results from the plugins

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -1,4 +1,11 @@
 Release Notes
+=============
+
+### v2.1.1
+- check to make sure that every result in the results array returned by the plugins
+  is not undefined so that we do not run into the problem of dereferencing undefined
+  results later on, which caused some exceptions
+
 ### v2.1.0
 - fixed a bug where the quote style checker was not converting the highlight quotes properly
 - added an option `output` to write the output to a file.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-lint",
-    "version": "2.1.0",
+    "version": "2.1.1",
     "module": "./src/index.js",
     "type": "module",
     "bin": "./src/index.js",

--- a/src/Project.js
+++ b/src/Project.js
@@ -523,7 +523,7 @@ class Project extends DirItem {
                 logger.error(`Error while finding issues in the file ${file.filePath}`);
                 logger.error(e);
             }
-        });
+        }).filter(result => result);
     }
 
     /**


### PR DESCRIPTION
- only allow through results that are not undefined so that we do not have dereference errors later on