### PR TITLE
Add the --no-return-value command-line flag

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -1,6 +1,12 @@
 Release Notes
 =============
 
+### v2.2.0
+- added --no-return-value command-line flag to have the linter always return 0, even
+  when there are errors and warnings. This still reports the results to the output.
+  The intention is that the linter can be used to report results without causing
+  build pipelines to fail.
+
 ### v2.1.1
 - check to make sure that every result in the results array returned by the plugins
   is not undefined so that we do not run into the problem of dereferencing undefined

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-lint",
-    "version": "2.1.1",
+    "version": "2.2.0",
     "module": "./src/index.js",
     "type": "module",
     "bin": "./src/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -131,6 +131,11 @@ const optionConfig = {
         help: "Give the minimum acceptable I18N score allowed in this run. Valid values are 0-100. Default: no minimum",
         type: validateInt.bind(null, "min-score")
     },
+    "no-return-value": {
+        flag: true,
+        "default": false,
+        help: "Print out results, but always exit with no return value, even when there are errors and warnings. (ie. return value 0)"
+    },
     output: {
         short: "o",
         varName: "fileName",
@@ -261,7 +266,7 @@ try {
     await rootProject.scan(paths);
     const exitValue = rootProject.run();
 
-    process.exit(exitValue);
+    process.exit(options.opt["no-return-value"] ? 0 : exitValue);
 } catch (e) {
     logger.error(e);
 }


### PR DESCRIPTION
- still prints out results, but always exits with return value 0.
- the intention is that we can use the linter in build pipelines to print out results, and yet not cause the build to fail