### PR TITLE
Give better error messages when parsing fails

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -1,6 +1,13 @@
 Release Notes
 =============
 
+### v2.2.1
+
+- fixed the output from the LintableFile class so that if there is only one
+  parser for the file, it will show the specific parser error that caused that
+  parsing problem instead of saying that none of the parsers could parse
+  the file without any specifics.
+
 ### v2.2.0
 - added --no-return-value command-line flag to have the linter always return 0, even
   when there are errors and warnings. This still reports the results to the output.

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -7,6 +7,7 @@ Release Notes
   parser for the file, it will show the specific parser error that caused that
   parsing problem instead of saying that none of the parsers could parse
   the file without any specifics.
+- updated dependencies
 
 ### v2.2.0
 - added --no-return-value command-line flag to have the linter always return 0, even

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-lint",
-    "version": "2.2.0",
+    "version": "2.2.1",
     "module": "./src/index.js",
     "type": "module",
     "bin": "./src/index.js",
@@ -60,29 +60,29 @@
         "types": "tsc -p ./jsconfig.json"
     },
     "devDependencies": {
-        "@tsconfig/node14": "^14.1.0",
-        "@types/node": "^20.11.27",
+        "@tsconfig/node14": "^14.1.2",
+        "@types/node": "^20.14.10",
         "docdash": "^2.0.2",
         "ilib-lint-plugin-test": "file:test/ilib-lint-plugin-test",
         "ilib-lint-plugin-obsolete": "file:test/ilib-lint-plugin-obsolete",
         "i18nlint-plugin-test-old": "file:test/i18nlint-plugin-test-old",
         "jest": "^29.7.0",
-        "jsdoc": "^4.0.2",
+        "jsdoc": "^4.0.3",
         "jsdoc-to-markdown": "^8.0.1",
         "npm-run-all": "^4.1.5",
-        "typescript": "^5.4.2"
+        "typescript": "^5.5.3"
     },
     "dependencies": {
-        "@formatjs/intl": "^2.10.0",
+        "@formatjs/intl": "^2.10.4",
         "ilib-common": "^1.1.3",
         "ilib-lint-common": "^3.0.0",
         "ilib-locale": "^1.2.2",
         "ilib-localeinfo": "^1.1.0",
-        "ilib-tools-common": "^1.9.1",
+        "ilib-tools-common": "^1.10.0",
         "intl-messageformat": "^10.5",
         "json5": "^2.2.3",
         "log4js": "^6.9.1",
-        "micromatch": "^4.0.5",
+        "micromatch": "^4.0.7",
         "options-parser": "^0.4.0"
     }
 }

--- a/src/LintableFile.js
+++ b/src/LintableFile.js
@@ -206,7 +206,13 @@ class LintableFile extends DirItem {
                 } while (didWrite);
                 this.irs = this.irs.concat(irs);
             } catch (e) {
-                debugger;
+                if (this.parsers.length === 1) {
+                    // if this is the only parser for this file, throw an exception right away so the user
+                    // can see what the specific parse error was from the parser
+                    throw new Error(`Could not parse file ${this.sourceFile.getPath()}. Try configuring another parser or excluding this file from the lint project.`, {
+                        cause: e
+                    });
+                }
                 logger.trace(`Parser ${parser.getName()} could not parse file ${this.sourceFile.getPath()}`);
                 logger.trace(e);
             }


### PR DESCRIPTION
- if there is only one parser for a file, show the actual parse error instead of a generic message that all parsers failed.
- updated dependencies