### PR TITLE
Implement XliffParser.write method

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -1,6 +1,11 @@
 Release Notes
 =============
 
+### v2.6.0
+
+- added XliffParser.write() method to generate the text of modified XLIFF files
+- added XliffParser.setContent() method to update the content of the XLIFF file
+
 ### v2.5.0
 
 - added the camel case match rule. If source strings contain only camel case and no whitespace, then the targets must be

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-lint",
-    "version": "2.5.0",
+    "version": "2.6.0",
     "module": "./src/index.js",
     "type": "module",
     "bin": "./src/index.js",
@@ -75,7 +75,7 @@
     "dependencies": {
         "@formatjs/intl": "^2.10.4",
         "ilib-common": "^1.1.3",
-        "ilib-lint-common": "^3.0.0",
+        "ilib-lint-common": "^3.1.0",
         "ilib-locale": "^1.2.2",
         "ilib-localeinfo": "^1.1.0",
         "ilib-tools-common": "^1.11.0",

--- a/src/plugins/BuiltinPlugin.js
+++ b/src/plugins/BuiltinPlugin.js
@@ -20,8 +20,11 @@
 
 import { Plugin } from 'ilib-lint-common';
 import XliffParser from './XliffParser.js';
+import XliffSerializer from './XliffSerializer.js';
 import LineParser from './LineParser.js';
+import LineSerializer from './LineSerializer.js';
 import StringParser from './string/StringParser.js';
+import StringSerializer from './string/StringSerializer.js';
 import AnsiConsoleFormatter from '../formatters/AnsiConsoleFormatter.js';
 import ResourceICUPlurals from '../rules/ResourceICUPlurals.js';
 import ResourceICUPluralTranslation from '../rules/ResourceICUPluralTranslation.js';
@@ -318,6 +321,17 @@ class BuiltinPlugin extends Plugin {
      */
     getParsers() {
         return [XliffParser, LineParser, StringParser];
+    }
+
+    /**
+     * For a "serializer" type of plugin, this returns a list of Serializer classes
+     * that this plugin implements.
+     *
+     * @returns {Array.<Parser>} list of Serializer classes implemented by this
+     * plugin
+     */
+    getSerializers() {
+        return [XliffSerializer, LineSerializer, StringSerializer];
     }
 
     /**

--- a/src/plugins/LineSerializer.js
+++ b/src/plugins/LineSerializer.js
@@ -1,0 +1,55 @@
+/*
+ * LineSerializer.js - Serializer for plain text files
+ *
+ * Copyright © 2024 JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Serializer, IntermediateRepresentation, SourceFile } from 'ilib-lint-common';
+
+/**
+ * @class Serializer for plain text files that splits them by lines
+ */
+class LineSerializer extends Serializer {
+    /**
+     * Construct a new plugin.
+     * @constructor
+     */
+    constructor(options) {
+        super(options);
+        this.name = "line";
+        this.description = "A serializer for plain text files that splits them into lines.";
+        this.type = "line";
+    }
+
+    /**
+     * Convert the intermediate representation back into a source file.
+     *
+     * @override
+     * @param {IntermediateRepresentation} ir the intermediate representation to convert
+     * @returns {SourceFile} the source file with the contents of the intermediate
+     * representation
+     */
+    serialize(ir) {
+        const lines = ir.getRepresentation();
+        const data = lines.join("\n");
+        return new SourceFile(ir.sourceFile.getPath(), {
+            file: ir.sourceFile,
+            content: data
+        });
+    }
+};
+
+export default LineSerializer;

--- a/src/plugins/XliffParser.js
+++ b/src/plugins/XliffParser.js
@@ -73,28 +73,6 @@ class XliffParser extends Parser {
     getExtensions() {
         return this.extensions;
     }
-
-    /**
-     * Convert the intermediate representation back into a source file.
-     *
-     * @override
-     * @param {IntermediateRepresentation} ir the intermediate representation to convert
-     * @returns {SourceFile} the source file with the contents of the intermediate
-     * representation
-     */
-    write(ir) {
-        const resources = ir.getRepresentation();
-        const xliff = new ResourceXliff({
-            path: ir.sourceFile.getPath()
-        });
-        resources.forEach(resource => {
-            xliff.addResource(resource);
-        });
-        const data = xliff.getText();
-        ir.sourceFile.setContent(data);
-        ir.sourceFile.write();
-        return ir.sourceFile;
-    }
 }
 
 export default XliffParser;

--- a/src/plugins/XliffSerializer.js
+++ b/src/plugins/XliffSerializer.js
@@ -1,0 +1,62 @@
+/*
+ * XliffSerializer.js - Serializer for XLIFF files
+ *
+ * Copyright © 2024 JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ResourceXliff } from 'ilib-tools-common';
+import { Serializer, IntermediateRepresentation, SourceFile } from 'ilib-lint-common';
+
+/**
+ * @class Serializer for XLIFF files based on the ilib-xliff library.
+ */
+class XliffSerializer extends Serializer {
+    /**
+     * Construct a new plugin.
+     * @constructor
+     */
+    constructor(options) {
+        super(options);
+        this.name = "xliff";
+        this.description = "A serializer for xliff files. This can handle xliff v1.2 and v2.0 format files.";
+        this.type = "resource";
+    }
+
+    /**
+     * Convert the intermediate representation back into a source file.
+     *
+     * @override
+     * @param {IntermediateRepresentation} ir the intermediate representation to convert
+     * @returns {SourceFile} the source file with the contents of the intermediate
+     * representation
+     */
+    serialize(ir) {
+        const resources = ir.getRepresentation();
+        const xliff = new ResourceXliff({
+            path: ir.sourceFile.getPath()
+        });
+        resources.forEach(resource => {
+            xliff.addResource(resource);
+        });
+        const data = xliff.getText();
+        return new SourceFile(ir.sourceFile.getPath(), {
+            file: ir.sourceFile,
+            content: data
+        });
+    }
+}
+
+export default XliffSerializer;

--- a/src/plugins/string/StringSerializer.js
+++ b/src/plugins/string/StringSerializer.js
@@ -1,0 +1,56 @@
+/*
+ * StringSerializer.js - Serializer for plain text files
+ *
+ * Copyright © 2024 JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Serializer, IntermediateRepresentation, SourceFile } from 'ilib-lint-common';
+
+/**
+ * @class Serializer for plain text files that treats the whole file as a
+ * simple string.
+ */
+class StringSerializer extends Serializer {
+    /**
+     * Construct a new plugin.
+     * @constructor
+     */
+    constructor(options = {}) {
+        super(options);
+
+        this.name = "string";
+        this.description = "A serializer for plain text files treats the whole file as a simple string.";
+        this.type = "string";
+    }
+
+    /**
+     * Convert the intermediate representation back into a source file.
+     *
+     * @override
+     * @param {IntermediateRepresentation} ir the intermediate representation to convert
+     * @returns {SourceFile} the source file with the contents of the intermediate
+     * representation
+     */
+    serialize(ir) {
+        const data = ir.getRepresentation();
+        return new SourceFile(ir.sourceFile.getPath(), {
+            file: ir.sourceFile,
+            content: data
+        });
+    }
+};
+
+export default StringSerializer;

--- a/test/XliffParser.test.js
+++ b/test/XliffParser.test.js
@@ -1,0 +1,34 @@
+/*
+ * XliffParser.test.js - test the built-in XliffParser plugin
+ *
+ * Copyright © 2024 JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ResourceArray, ResourcePlural, ResourceString } from 'ilib-tools-common';
+
+import { IntermediateRepresentation, SourceFile } from 'ilib-lint-common';
+import XliffParser from '../src/plugins/XliffParser.js';
+
+const sourceFile = new SourceFile("a/b/c.xliff", {});
+
+describe("test the XliffParser plugin", () => {
+    test("No arg constructor gives default values", () => {
+        expect.assertions(1);
+
+        const xp = new XliffParser();
+
+        expect(xp.getDescription()).toBe("A parser for xliff files. This can handle xliff v1.2 and v2.0 format files.");
+    });
+});

--- a/test/XliffParser.test.js
+++ b/test/XliffParser.test.js
@@ -18,10 +18,16 @@
  */
 import fs from 'fs';
 
-import { ResourceArray, ResourcePlural, ResourceString } from 'ilib-tools-common';
+import { ResourceString } from 'ilib-tools-common';
 
 import { IntermediateRepresentation, SourceFile } from 'ilib-lint-common';
 import XliffParser from '../src/plugins/XliffParser.js';
+
+import {describe, expect, test} from '@jest/globals';
+
+/**
+ * @jest-environment node
+ */
 
 describe("test the XliffParser plugin", () => {
     test("No arg constructor gives default values", () => {
@@ -108,103 +114,5 @@ describe("test the XliffParser plugin", () => {
         expect(() => {
             xp.parse(sourceFile);
         }).toThrow();
-    });
-
-    test("Write a regular xliff file but don't change the content", () => {
-        expect.assertions(3);
-
-        const xp = new XliffParser();
-
-        const sourceFile = new SourceFile("test/testfiles/xliff/test.xliff", {});
-        const expected = sourceFile.getContent();
-
-        const ir = xp.parse(sourceFile);
-        expect(ir).toBeTruthy();
-        expect(xp.write(ir[0])).toBe(sourceFile);
-
-        // the content has not changed
-        expect(sourceFile.getContent()).toBe(expected);
-    });
-
-    test("Write a regular xliff file and change the content", () => {
-        expect.assertions(4);
-
-        const xp = new XliffParser();
-
-        const sourceFile = new SourceFile("test/testfiles/xliff/test.xliff", {});
-        const oldContent = sourceFile.getContent();
-
-        const ir = xp.parse(sourceFile);
-        expect(ir).toBeTruthy();
-
-        const resources = ir[0].getRepresentation();
-        resources[0].setTarget("new target");
-
-        // write to a different file so we can compare the content
-        ir[0].sourceFile.filePath = "test/testfiles/xliff/test-changed.xliff";
-
-        const newSourceFile = xp.write(ir[0]);
-        expect(newSourceFile).toBe(sourceFile);
-
-        // the content has changed
-        const newContent = newSourceFile.getContent();
-        expect(newContent).not.toBe(oldContent);
-
-        // the content is what we expect
-        expect(newContent).toBe(
-`<?xml version="1.0" encoding="utf-8"?>
-<xliff version="1.2">
-  <file original="foo/bar/asdf.java" source-language="en-US" target-language="de-DE" product-name="webapp">
-    <body>
-      <trans-unit id="1" resname="foobar" restype="string" datatype="plaintext">
-        <source>Asdf asdf</source>
-        <target>new target</target>
-        <note>foobar is where it's at!</note>
-      </trans-unit>
-    </body>
-  </file>
-</xliff>`);
-
-    });
-
-    test("Write a regular xliff file and change the content on disk", () => {
-        expect.assertions(4);
-
-        const xp = new XliffParser();
-
-        const sourceFile = new SourceFile("test/testfiles/xliff/test.xliff", {});
-        const oldContent = sourceFile.getContent();
-
-        const ir = xp.parse(sourceFile);
-        expect(ir).toBeTruthy();
-
-        const resources = ir[0].getRepresentation();
-        resources[0].setTarget("new target");
-
-        // write to a different file so we can compare the content
-        ir[0].sourceFile.filePath = "test/testfiles/xliff/test-changed.xliff";
-
-        const newSourceFile = xp.write(ir[0]);
-        expect(newSourceFile).toBe(sourceFile);
-
-        // the content has changed
-        const newContent = fs.readFileSync("test/testfiles/xliff/test-changed.xliff", "utf-8");
-        expect(newContent).not.toBe(oldContent);
-
-        // the content is what we expect
-        expect(newContent).toBe(
-`<?xml version="1.0" encoding="utf-8"?>
-<xliff version="1.2">
-  <file original="foo/bar/asdf.java" source-language="en-US" target-language="de-DE" product-name="webapp">
-    <body>
-      <trans-unit id="1" resname="foobar" restype="string" datatype="plaintext">
-        <source>Asdf asdf</source>
-        <target>new target</target>
-        <note>foobar is where it's at!</note>
-      </trans-unit>
-    </body>
-  </file>
-</xliff>`);
-
     });
 });

--- a/test/XliffParser.test.js
+++ b/test/XliffParser.test.js
@@ -16,6 +16,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import fs from 'fs';
+
 import { ResourceArray, ResourcePlural, ResourceString } from 'ilib-tools-common';
 
 import { IntermediateRepresentation, SourceFile } from 'ilib-lint-common';
@@ -35,9 +37,9 @@ describe("test the XliffParser plugin", () => {
 
     test("Parse a regular xliff file", () => {
         expect.assertions(11);
-    
+
         const xp = new XliffParser();
-    
+
         const sourceFile = new SourceFile("test/testfiles/xliff/test.xliff", {});
 
         const ir = xp.parse(sourceFile);
@@ -106,5 +108,103 @@ describe("test the XliffParser plugin", () => {
         expect(() => {
             xp.parse(sourceFile);
         }).toThrow();
+    });
+
+    test("Write a regular xliff file but don't change the content", () => {
+        expect.assertions(3);
+
+        const xp = new XliffParser();
+
+        const sourceFile = new SourceFile("test/testfiles/xliff/test.xliff", {});
+        const expected = sourceFile.getContent();
+
+        const ir = xp.parse(sourceFile);
+        expect(ir).toBeTruthy();
+        expect(xp.write(ir[0])).toBe(sourceFile);
+
+        // the content has not changed
+        expect(sourceFile.getContent()).toBe(expected);
+    });
+
+    test("Write a regular xliff file and change the content", () => {
+        expect.assertions(4);
+
+        const xp = new XliffParser();
+
+        const sourceFile = new SourceFile("test/testfiles/xliff/test.xliff", {});
+        const oldContent = sourceFile.getContent();
+
+        const ir = xp.parse(sourceFile);
+        expect(ir).toBeTruthy();
+
+        const resources = ir[0].getRepresentation();
+        resources[0].setTarget("new target");
+
+        // write to a different file so we can compare the content
+        ir[0].sourceFile.filePath = "test/testfiles/xliff/test-changed.xliff";
+
+        const newSourceFile = xp.write(ir[0]);
+        expect(newSourceFile).toBe(sourceFile);
+
+        // the content has changed
+        const newContent = newSourceFile.getContent();
+        expect(newContent).not.toBe(oldContent);
+
+        // the content is what we expect
+        expect(newContent).toBe(
+`<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2">
+  <file original="foo/bar/asdf.java" source-language="en-US" target-language="de-DE" product-name="webapp">
+    <body>
+      <trans-unit id="1" resname="foobar" restype="string" datatype="plaintext">
+        <source>Asdf asdf</source>
+        <target>new target</target>
+        <note>foobar is where it's at!</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>`);
+
+    });
+
+    test("Write a regular xliff file and change the content on disk", () => {
+        expect.assertions(4);
+
+        const xp = new XliffParser();
+
+        const sourceFile = new SourceFile("test/testfiles/xliff/test.xliff", {});
+        const oldContent = sourceFile.getContent();
+
+        const ir = xp.parse(sourceFile);
+        expect(ir).toBeTruthy();
+
+        const resources = ir[0].getRepresentation();
+        resources[0].setTarget("new target");
+
+        // write to a different file so we can compare the content
+        ir[0].sourceFile.filePath = "test/testfiles/xliff/test-changed.xliff";
+
+        const newSourceFile = xp.write(ir[0]);
+        expect(newSourceFile).toBe(sourceFile);
+
+        // the content has changed
+        const newContent = fs.readFileSync("test/testfiles/xliff/test-changed.xliff", "utf-8");
+        expect(newContent).not.toBe(oldContent);
+
+        // the content is what we expect
+        expect(newContent).toBe(
+`<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2">
+  <file original="foo/bar/asdf.java" source-language="en-US" target-language="de-DE" product-name="webapp">
+    <body>
+      <trans-unit id="1" resname="foobar" restype="string" datatype="plaintext">
+        <source>Asdf asdf</source>
+        <target>new target</target>
+        <note>foobar is where it's at!</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>`);
+
     });
 });

--- a/test/XliffParser.test.js
+++ b/test/XliffParser.test.js
@@ -21,14 +21,90 @@ import { ResourceArray, ResourcePlural, ResourceString } from 'ilib-tools-common
 import { IntermediateRepresentation, SourceFile } from 'ilib-lint-common';
 import XliffParser from '../src/plugins/XliffParser.js';
 
-const sourceFile = new SourceFile("a/b/c.xliff", {});
-
 describe("test the XliffParser plugin", () => {
     test("No arg constructor gives default values", () => {
-        expect.assertions(1);
+        expect.assertions(4);
 
         const xp = new XliffParser();
 
         expect(xp.getDescription()).toBe("A parser for xliff files. This can handle xliff v1.2 and v2.0 format files.");
+        expect(xp.getExtensions()).toEqual(["xliff", "xlif", "xlf"]);
+        expect(xp.getType()).toBe("resource");
+        expect(xp.getName()).toBe("xliff");
+    });
+
+    test("Parse a regular xliff file", () => {
+        expect.assertions(11);
+    
+        const xp = new XliffParser();
+    
+        const sourceFile = new SourceFile("test/testfiles/xliff/test.xliff", {});
+
+        const ir = xp.parse(sourceFile);
+        expect(ir).toBeTruthy();
+        expect(ir.length).toBe(1);
+        expect(ir[0] instanceof IntermediateRepresentation).toBeTruthy();
+
+        const resources = ir[0].getRepresentation();
+        expect(resources).toBeTruthy();
+        expect(resources.length).toBe(1);
+
+        const resource = resources[0];
+        expect(resource instanceof ResourceString).toBeTruthy();
+        expect(resource.getSourceLocale()).toBe("en-US");
+        expect(resource.getSource()).toBe("Asdf asdf");
+
+        expect(resource.getTargetLocale()).toBe("de-DE");
+        expect(resource.getTarget()).toBe("foobarfoo");
+
+        expect(resource.getComment()).toBe("foobar is where it's at!");
+    });
+
+    test("Correctly throw when parsing a malformed xliff file", () => {
+        expect.assertions(1);
+
+        const xp = new XliffParser();
+
+        const sourceFile = new SourceFile("test/testfiles/xliff/bad.xliff", {});
+
+        expect(() => {
+            xp.parse(sourceFile);
+        }).toThrow();
+    });
+
+    test("Correctly throw when parsing a non-xliff file", () => {
+        expect.assertions(1);
+
+        const xp = new XliffParser();
+
+        const sourceFile = new SourceFile("test/testfiles/strings.xyz", {});
+
+        expect(() => {
+            xp.parse(sourceFile);
+        }).toThrow();
+    });
+
+    test("Correctly throw when given a non-existent file", () => {
+        expect.assertions(1);
+
+        const xp = new XliffParser();
+
+        const sourceFile = new SourceFile("test/testfiles/xliff/nonexistent.xliff", {});
+
+        expect(() => {
+            xp.parse(sourceFile);
+        }).toThrow();
+    });
+
+    test("Correctly throw when given a directory instead of a file", () => {
+        expect.assertions(1);
+
+        const xp = new XliffParser();
+
+        const sourceFile = new SourceFile("test/testfiles/xliff", {});
+
+        expect(() => {
+            xp.parse(sourceFile);
+        }).toThrow();
     });
 });

--- a/test/XliffSerializer.test.js
+++ b/test/XliffSerializer.test.js
@@ -1,0 +1,179 @@
+/*
+ * XliffSerializer.test.js - test the built-in XliffSerializer plugin
+ *
+ * Copyright © 2024 JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import fs from 'fs';
+
+import { ResourceArray, ResourcePlural, ResourceString } from 'ilib-tools-common';
+
+import { IntermediateRepresentation, SourceFile } from 'ilib-lint-common';
+import XliffParser from '../src/plugins/XliffParser.js';
+import XliffSerializer from '../src/plugins/XliffSerializer.js';
+
+describe("test the XliffParser plugin", () => {
+    test("No arg constructor gives default values", () => {
+        expect.assertions(3);
+
+        const xs = new XliffSerializer();
+
+        expect(xs.getDescription()).toBe("A serializer for xliff files. This can handle xliff v1.2 and v2.0 format files.");
+        expect(xs.getType()).toBe("resource");
+        expect(xs.getName()).toBe("xliff");
+    });
+
+    test("Serialize a regular xliff file", () => {
+        expect.assertions(3);
+
+        const sourceFile = new SourceFile("test/testfiles/xliff/test.xliff", {});
+
+        const ir = new IntermediateRepresentation({
+            type: "resource",
+            ir: [
+                new ResourceString({
+                    source: "Asdf asdf",
+                    sourceLocale: "en-US",
+                    target: "Asdf asdf in German",
+                    targetLocale: "de-DE",
+                    key: "foobar",
+                    datatype: "plaintext",
+                    restype: "string",
+                    project: "webapp",
+                    pathName: "foo/bar/asdf.java",
+                    comment: "foobar is where it's at!"
+                })
+            ],
+            sourceFile
+        });
+        
+        const xs = new XliffSerializer();
+        const newSourceFile = xs.serialize(ir);
+        expect(newSourceFile).toBeTruthy();
+        expect(newSourceFile.getPath()).toBe(sourceFile.getPath());
+        expect(newSourceFile.getContent()).toBe(
+`<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2">
+  <file original="foo/bar/asdf.java" source-language="en-US" target-language="de-DE" product-name="webapp">
+    <body>
+      <trans-unit id="1" resname="foobar" restype="string" datatype="plaintext">
+        <source>Asdf asdf</source>
+        <target>Asdf asdf in German</target>
+        <note>foobar is where it's at!</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>`);
+    });
+
+    test("Serialize a regular xliff file with multiple resources", () => {
+        expect.assertions(3);
+        
+        const sourceFile = new SourceFile("test/testfiles/xliff/test.xliff", {});
+        
+        const ir = new IntermediateRepresentation({
+            type: "resource",
+            ir: [
+                new ResourceString({
+                    source: "Asdf asdf",
+                    sourceLocale: "en-US",
+                    target: "Asdf asdf in German",
+                    targetLocale: "de-DE",
+                    key: "foobar",
+                    datatype: "plaintext",
+                    restype: "string",
+                    project: "webapp",
+                    pathName: "foo/bar/asdf.java",
+                    comment: "foobar is where it's at!"
+                }),
+                new ResourcePlural({
+                    source: {
+                        one: "You have one message.",
+                        other: "You have {n} messages."
+                    },
+                    sourceLocale: "en-US",
+                    target: {
+                        one: "Sie haben eine Nachricht.",
+                        other: "Sie haben {n} Nachrichten."
+                    },
+                    targetLocale: "de-DE",
+                    key: "messages",
+                    datatype: "plaintext",
+                    restype: "plural",
+                    project: "webapp",
+                    pathName: "foo/bar/asdf.java",
+                    comment: "messages are important"
+                }),
+                new ResourceArray({
+                    source: ["one", "two", "three"],
+                    sourceLocale: "en-US",
+                    target: ["eins", "zwei", "drei"],
+                    targetLocale: "de-DE",
+                    key: "numbers",
+                    datatype: "plaintext",
+                    restype: "array",
+                    project: "webapp",
+                    pathName: "foo/bar/asdf.java",
+                    comment: "numbers are numbers"
+                })
+            ],
+            sourceFile
+        });
+        
+        const xs = new XliffSerializer();
+        const newSourceFile = xs.serialize(ir);
+        expect(newSourceFile).toBeTruthy();
+        expect(newSourceFile.getPath()).toBe(sourceFile.getPath());
+        expect(newSourceFile.getContent()).toBe(
+`<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2">
+  <file original="foo/bar/asdf.java" source-language="en-US" target-language="de-DE" product-name="webapp">
+    <body>
+      <trans-unit id="1" resname="foobar" restype="string" datatype="plaintext">
+        <source>Asdf asdf</source>
+        <target>Asdf asdf in German</target>
+        <note>foobar is where it's at!</note>
+      </trans-unit>
+      <trans-unit id="2" resname="messages" restype="plural" datatype="plaintext" extype="one">
+        <source>You have one message.</source>
+        <target>Sie haben eine Nachricht.</target>
+        <note>messages are important</note>
+      </trans-unit>
+      <trans-unit id="3" resname="messages" restype="plural" datatype="plaintext" extype="other">
+        <source>You have {n} messages.</source>
+        <target>Sie haben {n} Nachrichten.</target>
+        <note>messages are important</note>
+      </trans-unit>
+      <trans-unit id="4" resname="numbers" restype="array" datatype="plaintext" extype="0">
+        <source>one</source>
+        <target>eins</target>
+        <note>numbers are numbers</note>
+      </trans-unit>
+      <trans-unit id="5" resname="numbers" restype="array" datatype="plaintext" extype="1">
+        <source>two</source>
+        <target>zwei</target>
+        <note>numbers are numbers</note>
+      </trans-unit>
+      <trans-unit id="6" resname="numbers" restype="array" datatype="plaintext" extype="2">
+        <source>three</source>
+        <target>drei</target>
+        <note>numbers are numbers</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>`);
+
+    });
+});

--- a/test/testfiles/xliff/bad.xliff
+++ b/test/testfiles/xliff/bad.xliff
@@ -5,8 +5,7 @@
       <trans-unit id="1" resname="foobar" restype="string" datatype="plaintext">
         <source>Asdf asdf</source>
         <target>foobarfoo</target>
-        <note>foobar is where it's at!</note>
+        <note annotates="source">foobar is where it&apos;s at!</note>
       </trans-unit>
-    </body>
   </file>
 </xliff>


### PR DESCRIPTION
- In preparation for making changes to the linter to modify and write out xliff files.
- Added unit tests for the xliff parser so we can verify this functionality
- This PR will not pass the checks until ilib-lint-common v3.1.0 is published, but I have tested it with v3.1.0 locally and all unit tests pass.